### PR TITLE
Fix unsafe-eval usage of "new Function()"

### DIFF
--- a/src/snackbar/snackbar.component.ts
+++ b/src/snackbar/snackbar.component.ts
@@ -69,9 +69,9 @@ export class SnackbarComponent {
 
     if (snack.action) {
       const that = this;
-      const fcn = snack.action.onClick || new Function();
+      const fcn = snack.action.onClick;
       snack.action.onClick = () => {
-        fcn(data);
+        fcn && typeof fcn === 'function' && fcn(data);
         that.remove(id);
       };
     }


### PR DESCRIPTION
Use waterfall check instead of value reassignment with CSP unsafe-eval violation "new Function()" call.

This prevents CSP errors when not providing an `onClick` property, since it is possible  to pass strings into ` new Function()`, which is just as unsafe as calling `eval()`.